### PR TITLE
Add BreakIt and MadCourses pages

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -24,7 +24,7 @@ button,
 
 :root {
   --background: #ffffff;
-  --foreground: #171717;
+  --foreground: #000000;
 }
 
 @theme inline {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,8 +3,10 @@
 import ColorBackground from "@/components/ColorBackground"
 import Cursor from "@/components/Cursor"
 import Intro from "@/pages/intro"
+import BreakIt from "@/pages/breakit"
+import MadCourses from "@/pages/madcourses"
 import { CursorProvider } from "@/context/CursorContext"
-import { ColorCycleProvider } from "@/context/ColorCycleContext"
+import { ColorCycleProvider, useColorCycle } from "@/context/ColorCycleContext"
 
 export default function Home() {
   return (
@@ -12,10 +14,17 @@ export default function Home() {
       <CursorProvider>
         <div className="relative h-screen overflow-hidden font-sans">
           <ColorBackground />
-          <Intro />
+          <PageSelector />
           <Cursor />
         </div>
       </CursorProvider>
     </ColorCycleProvider>
   )
+}
+
+function PageSelector() {
+  const { colorIndex } = useColorCycle()
+  if (colorIndex === 1) return <BreakIt />
+  if (colorIndex === 2) return <MadCourses />
+  return <Intro />
 }

--- a/src/pages/breakit.tsx
+++ b/src/pages/breakit.tsx
@@ -14,9 +14,9 @@ export default function BreakIt() {
 
   return (
     <>
-      <main className="flex flex-col h-full px-6 xl:text-7xl lg:text-6xl md:text-5xl sm:text-4xl text-lg font-light text-black">
+      <main className="flex flex-col h-full px-6 xl:text-7xl lg:text-6xl md:text-5xl sm:text-4xl text-lg font-light text-white">
         <span className="md:mt-16 sm:mt-8 mt-6 md:ml-8">
-          <Typewriter lines={["BreakIt"]} speed={35} />
+          <Typewriter lines={["BreakIt"]} speed={35} bold={["BreakIt"]} />
         </span>
       </main>
 

--- a/src/pages/breakit.tsx
+++ b/src/pages/breakit.tsx
@@ -1,0 +1,43 @@
+"use client"
+
+import Typewriter from "@/components/Typewriter"
+import { useCursorContext } from "@/context/CursorContext"
+import { useEffect } from "react"
+
+export default function BreakIt() {
+  const { setTargets } = useCursorContext()
+
+  useEffect(() => {
+    setTargets([])
+    return () => setTargets([])
+  }, [setTargets])
+
+  return (
+    <>
+      <main className="flex flex-col h-full px-6 xl:text-7xl lg:text-6xl md:text-5xl sm:text-4xl text-lg font-light text-gray-800">
+        <span className="md:mt-16 sm:mt-8 mt-6 md:ml-8">
+          <Typewriter lines={["BreakIt"]} speed={35} />
+        </span>
+      </main>
+
+      <section className="px-6 mt-8 text-gray-800">
+        <h2 className="text-2xl font-semibold mb-4">Project Overview</h2>
+        <p className="max-w-xl">This section will describe the BreakIt mobile application.</p>
+      </section>
+
+      <section className="px-6 mt-8">
+        <div className="flex space-x-4 overflow-x-auto py-2">
+          <div className="h-12 w-12 bg-gray-200 flex items-center justify-center rounded-md shrink-0">React</div>
+          <div className="h-12 w-12 bg-gray-200 flex items-center justify-center rounded-md shrink-0">Redux</div>
+          <div className="h-12 w-12 bg-gray-200 flex items-center justify-center rounded-md shrink-0">TS</div>
+        </div>
+      </section>
+
+      <section className="px-6 mt-8 flex flex-col items-center space-y-4">
+        <div className="w-64 h-96 bg-gray-300 flex items-center justify-center">
+          Phone screenshot
+        </div>
+      </section>
+    </>
+  )
+}

--- a/src/pages/breakit.tsx
+++ b/src/pages/breakit.tsx
@@ -14,13 +14,13 @@ export default function BreakIt() {
 
   return (
     <>
-      <main className="flex flex-col h-full px-6 xl:text-7xl lg:text-6xl md:text-5xl sm:text-4xl text-lg font-light text-gray-800">
+      <main className="flex flex-col h-full px-6 xl:text-7xl lg:text-6xl md:text-5xl sm:text-4xl text-lg font-light text-black">
         <span className="md:mt-16 sm:mt-8 mt-6 md:ml-8">
           <Typewriter lines={["BreakIt"]} speed={35} />
         </span>
       </main>
 
-      <section className="px-6 mt-8 text-gray-800">
+      <section className="px-6 mt-8 text-black">
         <h2 className="text-2xl font-semibold mb-4">Project Overview</h2>
         <p className="max-w-xl">This section will describe the BreakIt mobile application.</p>
       </section>

--- a/src/pages/intro.tsx
+++ b/src/pages/intro.tsx
@@ -20,7 +20,7 @@ export default function Intro() {
   return (
     <>
       {/* ───────────────────────── HEADER ───────────────────────── */}
-      <header className="absolute top-0 inset-x-0 h-16 flex items-center justify-end px-6 z-10 sm:text-lg text-sm font-medium text-gray-800">
+      <header className="absolute top-0 inset-x-0 h-16 flex items-center justify-end px-6 z-10 sm:text-lg text-sm font-medium text-black">
         <p>
           <a
             ref={resumeRef}
@@ -34,7 +34,7 @@ export default function Intro() {
       </header>
 
       {/* ───────────────────────── MAIN CONTENT ───────────────────────── */}
-      <main className="flex flex-col h-full px-6 xl:text-7xl lg:text-6xl md:text-5xl sm:text-4xl text-lg font-light text-gray-800">
+      <main className="flex flex-col h-full px-6 xl:text-7xl lg:text-6xl md:text-5xl sm:text-4xl text-lg font-light text-black">
         <span className="md:mt-16 sm:mt-8 mt-6 md:ml-8">
           <Typewriter
             lines={[
@@ -67,7 +67,7 @@ export default function Intro() {
           rel="noopener noreferrer"
           aria-label="GitHub Profile"
         >
-          <FaGithub className="w-6 h-6 text-gray-800 hover:text-gray-600 transition" />
+          <FaGithub className="w-6 h-6 text-black hover:text-gray-600 transition" />
         </a>
         <a
           ref={linkedinRef}
@@ -76,7 +76,7 @@ export default function Intro() {
           rel="noopener noreferrer"
           aria-label="LinkedIn Profile"
         >
-          <FaLinkedin className="w-6 h-6 text-gray-800 hover:text-gray-600 transition" />
+          <FaLinkedin className="w-6 h-6 text-black hover:text-gray-600 transition" />
         </a>
       </footer>
     </>

--- a/src/pages/madcourses.tsx
+++ b/src/pages/madcourses.tsx
@@ -14,13 +14,13 @@ export default function MadCourses() {
 
   return (
     <>
-      <main className="flex flex-col h-full px-6 xl:text-7xl lg:text-6xl md:text-5xl sm:text-4xl text-lg font-light text-black">
+      <main className="flex flex-col h-full px-6 xl:text-7xl lg:text-6xl md:text-5xl sm:text-4xl text-lg font-light text-white">
         <span className="md:mt-16 sm:mt-8 mt-6 md:ml-8">
-          <Typewriter lines={["MadCourses"]} speed={35} />
+          <Typewriter lines={["MadCourses"]} speed={35} bold={["MadCourses"]}/>
         </span>
       </main>
 
-      <section className="px-6 mt-8 text-black">
+      <section className="px-6 mt-8 text-white">
         <h2 className="text-2xl font-semibold mb-4">Project Overview</h2>
         <p className="max-w-xl">This section will describe the MadCourses desktop application.</p>
       </section>

--- a/src/pages/madcourses.tsx
+++ b/src/pages/madcourses.tsx
@@ -1,0 +1,43 @@
+"use client"
+
+import Typewriter from "@/components/Typewriter"
+import { useCursorContext } from "@/context/CursorContext"
+import { useEffect } from "react"
+
+export default function MadCourses() {
+  const { setTargets } = useCursorContext()
+
+  useEffect(() => {
+    setTargets([])
+    return () => setTargets([])
+  }, [setTargets])
+
+  return (
+    <>
+      <main className="flex flex-col h-full px-6 xl:text-7xl lg:text-6xl md:text-5xl sm:text-4xl text-lg font-light text-gray-800">
+        <span className="md:mt-16 sm:mt-8 mt-6 md:ml-8">
+          <Typewriter lines={["MadCourses"]} speed={35} />
+        </span>
+      </main>
+
+      <section className="px-6 mt-8 text-gray-800">
+        <h2 className="text-2xl font-semibold mb-4">Project Overview</h2>
+        <p className="max-w-xl">This section will describe the MadCourses desktop application.</p>
+      </section>
+
+      <section className="px-6 mt-8">
+        <div className="flex space-x-4 overflow-x-auto py-2">
+          <div className="h-12 w-12 bg-gray-200 flex items-center justify-center rounded-md shrink-0">PostgreSQL</div>
+          <div className="h-12 w-12 bg-gray-200 flex items-center justify-center rounded-md shrink-0">Python</div>
+          <div className="h-12 w-12 bg-gray-200 flex items-center justify-center rounded-md shrink-0">Svelte</div>
+        </div>
+      </section>
+
+      <section className="px-6 mt-8 flex flex-col items-center space-y-4">
+        <div className="w-96 h-64 bg-gray-300 flex items-center justify-center">
+          Desktop screenshot
+        </div>
+      </section>
+    </>
+  )
+}

--- a/src/pages/madcourses.tsx
+++ b/src/pages/madcourses.tsx
@@ -14,13 +14,13 @@ export default function MadCourses() {
 
   return (
     <>
-      <main className="flex flex-col h-full px-6 xl:text-7xl lg:text-6xl md:text-5xl sm:text-4xl text-lg font-light text-gray-800">
+      <main className="flex flex-col h-full px-6 xl:text-7xl lg:text-6xl md:text-5xl sm:text-4xl text-lg font-light text-black">
         <span className="md:mt-16 sm:mt-8 mt-6 md:ml-8">
           <Typewriter lines={["MadCourses"]} speed={35} />
         </span>
       </main>
 
-      <section className="px-6 mt-8 text-gray-800">
+      <section className="px-6 mt-8 text-black">
         <h2 className="text-2xl font-semibold mb-4">Project Overview</h2>
         <p className="max-w-xl">This section will describe the MadCourses desktop application.</p>
       </section>


### PR DESCRIPTION
## Summary
- create placeholder pages for BreakIt and MadCourses
- cycle between Intro, BreakIt and MadCourses based on color index

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68520fc8f2b08331bfe93ffbd3f2425f