### PR TITLE
Add scrolling animation to BreakIt page

### DIFF
--- a/src/pages/breakit.tsx
+++ b/src/pages/breakit.tsx
@@ -2,7 +2,27 @@
 
 import Typewriter from "@/components/Typewriter"
 import { useCursorContext } from "@/contexts/CursorContext"
-import { useEffect } from "react"
+import {
+  motion,
+  useScroll,
+  useTransform,
+  useMotionValueEvent,
+} from "motion/react"
+import { useEffect, useRef, useState } from "react"
+
+const IMAGES = Array.from({ length: 9 }, (_, i) => `/breakit/breakit_${i}.png`)
+
+const LINES = [
+  "BreakIt helps you quit bad habits.",
+  "Track your progress each day.",
+  "Set personalized goals.",
+  "Connect with friends for support.",
+  "Share achievements and milestones.",
+  "Earn rewards for consistency.",
+  "View detailed statistics.",
+  "Get reminders and tips.",
+  "Start breaking habits today.",
+]
 
 export default function BreakIt() {
   const { setTargets } = useCursorContext()
@@ -12,32 +32,40 @@ export default function BreakIt() {
     return () => setTargets([])
   }, [setTargets])
 
+  const containerRef = useRef<HTMLDivElement>(null)
+  const { scrollYProgress } = useScroll({
+    target: containerRef,
+    offset: ["start start", "end end"],
+  })
+  const step = useTransform(scrollYProgress, [0, 1], [0, IMAGES.length - 1])
+  const [index, setIndex] = useState(0)
+  useMotionValueEvent(step, "change", (v) => {
+    const next = Math.min(IMAGES.length - 1, Math.max(0, Math.floor(v)))
+    setIndex(next)
+  })
+
   return (
-    <>
-      <main className="flex flex-col h-full px-6 xl:text-7xl lg:text-6xl md:text-5xl sm:text-4xl text-lg font-light text-white">
-        <span className="md:mt-16 sm:mt-8 mt-6 md:ml-8">
-          <Typewriter lines={["BreakIt"]} speed={35} bold={["BreakIt"]} />
-        </span>
-      </main>
-
-      <section className="px-6 mt-8 text-black">
-        <h2 className="text-2xl font-semibold mb-4">Project Overview</h2>
-        <p className="max-w-xl">This section will describe the BreakIt mobile application.</p>
-      </section>
-
-      <section className="px-6 mt-8">
-        <div className="flex space-x-4 overflow-x-auto py-2">
-          <div className="h-12 w-12 bg-gray-200 flex items-center justify-center rounded-md shrink-0">React</div>
-          <div className="h-12 w-12 bg-gray-200 flex items-center justify-center rounded-md shrink-0">Redux</div>
-          <div className="h-12 w-12 bg-gray-200 flex items-center justify-center rounded-md shrink-0">TS</div>
+    <div
+      ref={containerRef}
+      style={{ height: `${IMAGES.length * 100}vh` }}
+      className="relative"
+    >
+      <div className="sticky top-0 h-screen flex items-center justify-center p-6">
+        <div className="w-1/2 flex justify-center">
+          <motion.img
+            key={index}
+            src={IMAGES[index]}
+            alt={`BreakIt screenshot ${index}`}
+            className="max-h-full w-auto"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ duration: 0.3 }}
+          />
         </div>
-      </section>
-
-      <section className="px-6 mt-8 flex flex-col items-center space-y-4">
-        <div className="w-64 h-96 bg-gray-300 flex items-center justify-center">
-          Phone screenshot
+        <div className="w-1/2 pl-6 xl:text-7xl lg:text-6xl md:text-5xl sm:text-4xl text-lg font-light text-white">
+          <Typewriter key={index} lines={[LINES[index]]} speed={35} bold={["BreakIt"]} />
         </div>
-      </section>
-    </>
+      </div>
+    </div>
   )
 }


### PR DESCRIPTION
## Summary
- add motion-based scroll animations for BreakIt screenshots
- display text with Typewriter that updates as the user scrolls

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6853783f3d748331a80e6c8810fcf0d8