### PR TITLE
Add scroll-based image showcase to BreakIt

### DIFF
--- a/src/pages/breakit.tsx
+++ b/src/pages/breakit.tsx
@@ -2,42 +2,71 @@
 
 import Typewriter from "@/components/Typewriter"
 import { useCursorContext } from "@/contexts/CursorContext"
-import { useEffect } from "react"
+import { useEffect, useRef, useState } from "react"
+import { motion, useInView } from "motion/react"
+
+type SectionData = {
+  image: string
+  lines: string[]
+}
+
+const SECTIONS: SectionData[] = Array.from({ length: 9 }, (_, i) => ({
+  image: `/breakit/breakit_${i}.png`,
+  lines: [`BreakIt ${i + 1}`],
+}))
+
+function ScrollSection({
+  data,
+  index,
+  setActive,
+}: {
+  data: SectionData
+  index: number
+  setActive: (index: number) => void
+}) {
+  const ref = useRef<HTMLDivElement>(null)
+  const inView = useInView(ref, { margin: "-50% 0px -50% 0px" })
+
+  useEffect(() => {
+    if (inView) setActive(index)
+  }, [inView, index, setActive])
+
+  return (
+    <section ref={ref} className="h-screen flex items-center justify-center p-6">
+      {inView && <Typewriter lines={data.lines} speed={35} bold={data.lines} />}
+    </section>
+  )
+}
 
 export default function BreakIt() {
   const { setTargets } = useCursorContext()
+  const [active, setActive] = useState(0)
 
   useEffect(() => {
     setTargets([])
     return () => setTargets([])
   }, [setTargets])
 
+  const current = SECTIONS[active]
+
   return (
-    <>
-      <main className="flex flex-col h-full px-6 xl:text-7xl lg:text-6xl md:text-5xl sm:text-4xl text-lg font-light text-white">
-        <span className="md:mt-16 sm:mt-8 mt-6 md:ml-8">
-          <Typewriter lines={["BreakIt"]} speed={35} bold={["BreakIt"]} />
-        </span>
-      </main>
-
-      <section className="px-6 mt-8 text-black">
-        <h2 className="text-2xl font-semibold mb-4">Project Overview</h2>
-        <p className="max-w-xl">This section will describe the BreakIt mobile application.</p>
-      </section>
-
-      <section className="px-6 mt-8">
-        <div className="flex space-x-4 overflow-x-auto py-2">
-          <div className="h-12 w-12 bg-gray-200 flex items-center justify-center rounded-md shrink-0">React</div>
-          <div className="h-12 w-12 bg-gray-200 flex items-center justify-center rounded-md shrink-0">Redux</div>
-          <div className="h-12 w-12 bg-gray-200 flex items-center justify-center rounded-md shrink-0">TS</div>
-        </div>
-      </section>
-
-      <section className="px-6 mt-8 flex flex-col items-center space-y-4">
-        <div className="w-64 h-96 bg-gray-300 flex items-center justify-center">
-          Phone screenshot
-        </div>
-      </section>
-    </>
+    <div className="flex">
+      <div className="sticky top-0 h-screen flex items-center justify-center w-1/2">
+        <motion.img
+          key={current.image}
+          src={current.image}
+          alt={`BreakIt screen ${active}`}
+          className="w-64 h-auto"
+          initial={{ opacity: 0, y: 50 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.4 }}
+        />
+      </div>
+      <div className="w-1/2">
+        {SECTIONS.map((section, i) => (
+          <ScrollSection key={i} data={section} index={i} setActive={setActive} />
+        ))}
+      </div>
+    </div>
   )
 }


### PR DESCRIPTION
## Summary
- transform `breakit` page into a scroll-based showcase
- image changes as sections scroll into view using `motion`
- typewriter text updates in each section

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68537dba23908331aec463758632fa9c