### PR TITLE
Add captions for BreakIt screenshots

### DIFF
--- a/src/contexts/ColorCycleContext.tsx
+++ b/src/contexts/ColorCycleContext.tsx
@@ -2,7 +2,7 @@
 
 import { createContext, useContext, useState } from "react"
 
-export const ACCENT_COLORS = ["#EFF1F3", "#586183", "#EA3A35"] as const
+export const ACCENT_COLORS = ["#EFF1F3", "#6F799F", "#EA3A35"] as const
 
 interface ColorCycleContextValue {
   colorIndex: number

--- a/src/pages/breakit.tsx
+++ b/src/pages/breakit.tsx
@@ -6,6 +6,7 @@ import {
   useScroll,
   useSpring,
   useTransform,
+  useInView,
 } from "motion/react"
 import { useRef } from "react"
 import Typewriter from "@/components/Typewriter"
@@ -31,6 +32,7 @@ function ImageCard({ id, text }: { id: number; text: string }) {
   const ref = useRef<HTMLDivElement>(null)
   const { scrollYProgress } = useScroll({ target: ref })
   const y = useParallax(scrollYProgress, 300)
+  const inView = useInView(ref, { once: true })
 
   return (
     <section className="h-screen snap-start grid grid-cols-3 items-center gap-x-16">
@@ -50,7 +52,7 @@ function ImageCard({ id, text }: { id: number; text: string }) {
         style={{ y }}
         className="col-span-2 text-8xl font-bold tracking-tight text-white pointer-events-none select-none"
       >
-        <Typewriter lines={[text]} speed={35} bold={[text]} />
+        {inView && <Typewriter lines={[text]} speed={35} bold={[text]} />}
       </motion.div>
     </section>
   )

--- a/src/pages/breakit.tsx
+++ b/src/pages/breakit.tsx
@@ -33,8 +33,8 @@ function ImageCard({ id, text }: { id: number; text: string }) {
   const y = useParallax(scrollYProgress, 300)
 
   return (
-    <section className="h-screen snap-start flex items-center justify-center relative">
-      <div ref={ref} className="relative w-82 h-[700px] -translate-x-20">
+    <section className="h-screen snap-start grid grid-cols-3 items-center gap-x-16">
+      <div ref={ref} className="relative w-82 h-[700px] justify-self-center">
         <div className="relative w-full h-full rounded-[2.5rem] bg-black shadow-2xl">
           <Image
             src={`/breakit/breakit_${id}.png`}
@@ -46,14 +46,12 @@ function ImageCard({ id, text }: { id: number; text: string }) {
         </div>
       </div>
 
-      <motion.h2
+      <motion.div
         style={{ y }}
-        className="absolute left-[calc(50%+300px)] top-1/2 -translate-y-1/2
-                   text-7xl font-bold tracking-tight text-white
-                   pointer-events-none select-none"
+        className="col-span-2 text-8xl font-bold tracking-tight text-white pointer-events-none select-none"
       >
-        {text}
-      </motion.h2>
+        <Typewriter lines={[text]} speed={35} bold={[text]} />
+      </motion.div>
     </section>
   )
 }

--- a/src/pages/breakit.tsx
+++ b/src/pages/breakit.tsx
@@ -11,11 +11,23 @@ import { useRef } from "react"
 import Typewriter from "@/components/Typewriter"
 import Image from "next/image"
 
+const captions = [
+  "User dashboard",
+  "Puzzle selection",
+  "Level details",
+  "Game board",
+  "Scoring summary",
+  "New challenge",
+  "Achievement unlocked",
+  "Share results",
+  "Leaderboard",
+]
+
 function useParallax(value: MotionValue<number>, distance: number) {
   return useTransform(value, [0, 1], [-distance, distance])
 }
 
-function ImageCard({ id }: { id: number }) {
+function ImageCard({ id, text }: { id: number; text: string }) {
   const ref = useRef<HTMLDivElement>(null)
   const { scrollYProgress } = useScroll({ target: ref })
   const y = useParallax(scrollYProgress, 300)
@@ -34,14 +46,14 @@ function ImageCard({ id }: { id: number }) {
         </div>
       </div>
 
-      <motion.h2
+      <motion.div
         style={{ y }}
-        className="absolute left-[calc(50%+300px)] top-1/2 -translate-y-1/2
-                   text-5xl font-bold tracking-tight text-white
+        className="absolute left-[calc(50%+400px)] top-1/2 -translate-y-1/2
+                   text-7xl font-bold tracking-tight text-white
                    pointer-events-none select-none"
       >
-        {`#00${id}`}
-      </motion.h2>
+        <Typewriter lines={[text]} speed={35} />
+      </motion.div>
     </section>
   )
 }
@@ -62,7 +74,7 @@ export default function Parallax() {
 
       <div className="snap-y snap-mandatory">
         {[0, 1, 2, 3, 4, 5, 6, 7, 8].map((img) => (
-          <ImageCard key={img} id={img} />
+          <ImageCard key={img} id={img} text={captions[img]} />
         ))}
         <motion.div
           className="fixed bottom-12 left-0 right-0 h-1 bg-white origin-left"

--- a/src/pages/breakit.tsx
+++ b/src/pages/breakit.tsx
@@ -12,11 +12,11 @@ import { useRef } from "react"
 import Typewriter from "@/components/Typewriter"
 import Image from "next/image"
 
-const captions = [
-  "User dashboard",
-  "Puzzle selection",
-  "Level details",
-  "Game board",
+const titles = [
+  "Welcome to BreakIt!",
+  "My Goals",
+  "The Challenge",
+  "What's Different?",
   "Scoring summary",
   "New challenge",
   "Achievement unlocked",
@@ -24,19 +24,55 @@ const captions = [
   "Leaderboard",
 ]
 
+const descriptions = [
+  "I’ve always believed in building with purpose. One of the strongest motivators for me to create something occurs when I believe I can solve a problem that both myself and others could benefit from. BreakIt was born when my dad pointed out my nail-picking habit, and I thought, 'There has to be a way to track this and stay accountable.' As you explore the app, I’ll walk you through the technologies that bring it to life. Enjoy! 🎉",
+  "When I begin a new project, I start by identifying the technologies I want to learn, though inevitably, additional tools emerge as development unfolds. BreakIt was my first React Native app, building on my existing React experience and giving me hands-on insight into cross-platform mobile development, which offers clear advantages over maintaining separate native codebases. Furthermore, I also set out to deepen my understanding of integrating TypeScript within the React Native library and persisting data on app close.",
+  "My greatest challenge in developing BreakIt was managing several nested Context providers, which quickly led to tangled and confusing state handling. To resolve this, I adopted Redux Toolkit, a library that consolidates state management with persistence, stores, and reducers. Although learning Redux Toolkit required me to step beyond the React material covered in my university’s Building User Interfaces course and refactor much of my codebase, it proved to be the perfect solution for my Context issues and introduced me to a powerful state-management tool I’ll continue using in future projects.",
+  "Although many habit-tracking apps exist, I wanted BreakIt to stand out with a more visual, less declarative design free of unnecessary complexity. I created a clean, intuitive interface that places users’ progress front and center—eliminating clutter while keeping the experience engaging thanks to the dynamic art created by my friend, Emily. Some features now invite exploration on the user’s part, striking a balance between simplicity and discoverability. Thanks Emily! 🎨",
+  "Scoring summary",
+  "New challenge",
+  "Achievement unlocked",
+  "Share results",
+  "Leaderboard",
+]
+
+const descriptions_bold = [
+  ["purpose", "problem", "others", "could", "benefit", "from", "technologies", "Enjoy"],
+  ["learn", "React", "Native", "TypeScript", "persisting", "data"],
+  ["challenge", "Context", "state", "Redux", "Toolkit", "React", "Building", "User", "Interfaces"],
+  ["clean", "intuitive", "interface", "dynamic", "exploration", "simplicity", "discoverability"],
+  ["Scoring summary"],
+  ["New challenge"],
+  ["Achievement unlocked"],
+  ["Share results"],
+  ["Leaderboard"],
+]
+
 function useParallax(value: MotionValue<number>, distance: number) {
   return useTransform(value, [0, 1], [-distance, distance])
 }
 
-function ImageCard({ id, text }: { id: number; text: string }) {
+function ImageCard({
+  id,
+  title,
+  description,
+  bold
+}: {
+  id: number
+  title: string
+  description: string
+  bold: string[]
+}) {
   const ref = useRef<HTMLDivElement>(null)
   const { scrollYProgress } = useScroll({ target: ref })
   const y = useParallax(scrollYProgress, 300)
-  const inView = useInView(ref, { once: true })
+  const inView = useInView(ref, {
+    margin: "0px 0px -800px 0px",
+  })
 
   return (
-    <section className="h-screen snap-start grid grid-cols-3 items-center gap-x-16">
-      <div ref={ref} className="relative w-82 h-[700px] justify-self-center">
+    <section className="h-screen snap-start grid grid-cols-2 items-center">
+      <div ref={ref} className="relative w-5/12 h-10/12 justify-self-center">
         <div className="relative w-full h-full rounded-[2.5rem] bg-black shadow-2xl">
           <Image
             src={`/breakit/breakit_${id}.png`}
@@ -50,9 +86,16 @@ function ImageCard({ id, text }: { id: number; text: string }) {
 
       <motion.div
         style={{ y }}
-        className="col-span-2 text-8xl font-bold tracking-tight text-white pointer-events-none select-none"
+        className="col-span-1 text-8xl font-bold tracking-tight text-white pointer-events-none select-none"
       >
-        {inView && <Typewriter lines={[text]} speed={35} bold={[text]} />}
+        {inView && (
+          <div>
+            <Typewriter lines={[title]} speed={35} bold={[title]} />
+            <div className="text-4xl font-medium mt-4 mr-20 text-neutral-100">
+              <Typewriter lines={[description]} speed={3} bold={bold}/>
+            </div>
+          </div>
+        )}
       </motion.div>
     </section>
   )
@@ -74,7 +117,13 @@ export default function Parallax() {
 
       <div className="snap-y snap-mandatory">
         {[0, 1, 2, 3, 4, 5, 6, 7, 8].map((img) => (
-          <ImageCard key={img} id={img} text={captions[img]} />
+          <ImageCard
+            key={img}
+            id={img}
+            title={titles[img]}
+            description={descriptions[img]}
+            bold={descriptions_bold[img]}
+          />
         ))}
         <motion.div
           className="fixed bottom-12 left-0 right-0 h-1 bg-white origin-left"

--- a/src/pages/breakit.tsx
+++ b/src/pages/breakit.tsx
@@ -73,12 +73,12 @@ function ImageCard({
   return (
     <section className="h-screen snap-start grid grid-cols-2 items-center">
       <div ref={ref} className="relative w-5/12 h-10/12 justify-self-center">
-        <div className="relative w-full h-full rounded-[2.5rem] bg-black shadow-2xl">
+        <div className="relative w-full h-full rounded-[4rem] bg-black shadow-2xl">
           <Image
             src={`/breakit/breakit_${id}.png`}
             alt={`BreakIt ${id}`}
             fill
-            className="p-2 rounded-[2.5rem]"
+            className="p-2 rounded-[4rem]"
             priority={id === 0}
           />
         </div>

--- a/src/pages/breakit.tsx
+++ b/src/pages/breakit.tsx
@@ -34,7 +34,7 @@ function ImageCard({ id, text }: { id: number; text: string }) {
 
   return (
     <section className="h-screen snap-start flex items-center justify-center relative">
-      <div ref={ref} className="relative w-82 h-[700px]">
+      <div ref={ref} className="relative w-82 h-[700px] -translate-x-20">
         <div className="relative w-full h-full rounded-[2.5rem] bg-black shadow-2xl">
           <Image
             src={`/breakit/breakit_${id}.png`}
@@ -46,14 +46,14 @@ function ImageCard({ id, text }: { id: number; text: string }) {
         </div>
       </div>
 
-      <motion.div
+      <motion.h2
         style={{ y }}
-        className="absolute left-[calc(50%+400px)] top-1/2 -translate-y-1/2
+        className="absolute left-[calc(50%+300px)] top-1/2 -translate-y-1/2
                    text-7xl font-bold tracking-tight text-white
                    pointer-events-none select-none"
       >
-        <Typewriter lines={[text]} speed={35} />
-      </motion.div>
+        {text}
+      </motion.h2>
     </section>
   )
 }


### PR DESCRIPTION
## Summary
- show captions beside BreakIt screenshots
- replace `#00{id}` text with a Typewriter effect
- space out the caption from the phone and enlarge the text

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Merriweather`)*

------
https://chatgpt.com/codex/tasks/task_e_6854c1c640f883318565495aeba593ea