### PR TITLE
Add Row layout component and update BreakIt page

### DIFF
--- a/src/components/Row.tsx
+++ b/src/components/Row.tsx
@@ -1,0 +1,27 @@
+import React from "react"
+
+export type RowChild = [React.ReactNode, number]
+
+interface RowProps {
+  /** Total number of columns for the grid */
+  columns: number
+  /** Each child paired with the number of columns it spans */
+  items: RowChild[]
+  /** Additional classes for the container */
+  className?: string
+}
+
+export default function Row({ columns, items, className = "" }: RowProps) {
+  return (
+    <div
+      className={`grid ${className}`.trim()}
+      style={{ gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))` }}
+    >
+      {items.map(([child, span], idx) => (
+        <div key={idx} style={{ gridColumn: `span ${span} / span ${span}` }}>
+          {child}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/pages/breakit.tsx
+++ b/src/pages/breakit.tsx
@@ -10,6 +10,7 @@ import {
 } from "motion/react"
 import { useRef } from "react"
 import Typewriter from "@/components/Typewriter"
+import Row from "@/components/Row"
 import Image from "next/image"
 
 const titles = [
@@ -56,32 +57,44 @@ function ImageCard({
   })
 
   return (
-    <section className="h-screen snap-start grid grid-cols-2 items-center">
-      <div ref={ref} className="relative w-5/12 h-10/12 justify-self-center">
-        <div className="relative w-full h-full rounded-[4rem] bg-black shadow-2xl">
-          <Image
-            src={`/breakit/breakit_${id}.png`}
-            alt={`BreakIt ${id}`}
-            fill
-            className="p-2 rounded-[4rem]"
-            priority={id === 0}
-          />
-        </div>
-      </div>
-
-      <motion.div
-        style={{ y }}
-        className="col-span-1 text-8xl font-bold tracking-tight text-white pointer-events-none select-none"
-      >
-        {inView && (
-          <div>
-            <Typewriter lines={[title]} speed={35} bold={[title]} />
-            <div className="text-4xl font-medium mt-4 mr-20 text-neutral-100">
-              <Typewriter lines={[description]} speed={3} bold={bold}/>
-            </div>
-          </div>
-        )}
-      </motion.div>
+    <section className="h-screen snap-start">
+      <Row
+        columns={3}
+        className="h-full items-center"
+        items={[
+          [
+            <div ref={ref} className="relative w-5/12 h-10/12 justify-self-center" key="img">
+              <div className="relative w-full h-full rounded-[4rem] bg-black shadow-2xl">
+                <Image
+                  src={`/breakit/breakit_${id}.png`}
+                  alt={`BreakIt ${id}`}
+                  fill
+                  className="p-2 rounded-[4rem]"
+                  priority={id === 0}
+                />
+              </div>
+            </div>,
+            1,
+          ],
+          [
+            <motion.div
+              style={{ y }}
+              className="text-8xl font-bold tracking-tight text-white pointer-events-none select-none"
+              key="text"
+            >
+              {inView && (
+                <div>
+                  <Typewriter lines={[title]} speed={35} bold={[title]} />
+                  <div className="text-4xl font-medium mt-4 mr-20 text-neutral-100">
+                    <Typewriter lines={[description]} speed={3} bold={bold} />
+                  </div>
+                </div>
+              )}
+            </motion.div>,
+            2,
+          ],
+        ]}
+      />
     </section>
   )
 }


### PR DESCRIPTION
## Summary
- add a generic `Row` component that lays out children in a grid
- refactor BreakIt image cards to use `Row`

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Merriweather` due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6855e02b237c833181f04a3804293d28