### PR TITLE
Add MadCourses page with card data

### DIFF
--- a/src/data/madcoursesCards.ts
+++ b/src/data/madcoursesCards.ts
@@ -1,0 +1,63 @@
+// Structure describing a single info card.
+export type Card = {
+  /** Image index used for the initial screenshot */
+  image: number
+  /** Name of the icon shown behind the screenshot */
+  icon?: string
+  /** Lines for the title typewriter */
+  titleLines: string[]
+  /** Lines for the description typewriter */
+  descLines: string[]
+  /** Words that should be bold in the description */
+  bold: string[]
+}
+
+// Content used on the MadCourses page.
+export const CARDS: Card[] = [
+  {
+    image: 1,
+    titleLines: ["What is MadCourses..."],
+    descLines: [
+      "MadCourses is a tool I built in my final months in college. I was thinking back on what I wish I had. I knew I wanted to major in computer science back in elementary school and I knew what many companies were asking for, but what did that mean for me in college? How ccould I maximize my time? I would have loved a tool that told me which class most directly matches job skills with courses from UW-Madison, so I developed MadCourses.",
+    ],
+    bold: [
+      "MadCourses",
+      "college",
+      "computer",
+      "science",
+      "maximize",
+      "tool",
+      "matches",
+    ],
+  },
+  {
+    image: 2,
+    icon: "postgresql.svg",
+    titleLines: ["...and what's going on under the hood?"],
+    descLines: [
+      "I took the publicly available course registry from UW-Madison’s website and turned that into a PostgreSQL database with a python script I wrote. I then used a LLM to transform course descriptions into a set of vectors to be matched against a set of vectors created by user-entered skills. The more similar these vector sets are, the more likely that course corresponds to that skill.",
+    ],
+    bold: [
+      "PostgreSQL",
+      "python",
+      "LLM",
+      "vectors",
+      "skills",
+    ],
+  },
+  {
+    image: 1,
+    icon: "svelte.svg",
+    titleLines: ["What I wanted to learn"],
+    descLines: [
+      "As mentioned, the primary focus for me was the database side of things. I noticed that having experience with PostgreSQL would be useful because of how prevalent it is in the industry. This also helped me avoid having to locally some type of course directory, improving user experience. Furthermore, I wanted more front-end development skill aside from React and React Native alone. I had heard of Svelte as an emerging, arguably more streamlined framework so I decided early on that I would make a user interface with Svelte. My Svelte UI is dynamic and makes filtering courses easy, furthering the capabilities of MadCourses.",
+    ],
+    bold: [
+      "database",
+      "PostgreSQL",
+      "user",
+      "Svelte",
+      "dynamic",
+    ],
+  },
+]

--- a/src/pages/madcourses.tsx
+++ b/src/pages/madcourses.tsx
@@ -1,23 +1,112 @@
 "use client"
 
+import { motion, MotionValue, useScroll, useSpring, useTransform, useInView } from "motion/react"
+import { useRef, useEffect } from "react"
 import Typewriter from "@/components/Typewriter"
+import Image from "next/image"
+import { CARDS, Card } from "@/data/madcoursesCards"
 import { useCursorContext } from "@/contexts/CursorContext"
-import { useEffect } from "react"
 
-// Placeholder page for the MadCourses project.
+// Map scroll progress to a vertical offset for parallax motion.
+function useParallax(value: MotionValue<number>, distance: number) {
+  return useTransform(value, [0, 1], [-distance, distance])
+}
+
+// Card displaying an image with optional icon and parallax text.
+function InfoCard({ card }: { card: Card }) {
+  const ref = useRef<HTMLDivElement>(null)
+  const { scrollYProgress } = useScroll({ target: ref })
+  const y = useParallax(scrollYProgress, 300)
+  const inView = useInView(ref, { margin: "0px 0px -800px 0px" })
+
+  const isFirstImage = card.image === 1
+
+  return (
+    <section className="relative h-screen snap-start grid grid-cols-2 items-center">
+      {card.icon && (
+        <Image
+          src={`/icons/${card.icon}`}
+          alt=""
+          width={512}
+          height={512}
+          aria-hidden
+          className="pointer-events-none absolute left-1/11 -translate-x-1/2 -translate-y-1/3 w-[30vw] h-[30vw] -z-10 opacity-75 invert"
+        />
+      )}
+      <div ref={ref} className="relative w-5/12 h-10/12 justify-self-center">
+        <div className="relative w-full h-full rounded-[4rem] bg-black shadow-2xl">
+          <Image
+            src={`/madcourses/madcourses_${card.image}.png`}
+            alt={`MadCourses ${card.image}`}
+            fill
+            className="p-2 rounded-[4rem]"
+            priority={isFirstImage}
+          />
+        </div>
+      </div>
+
+      <motion.div
+        style={{ y }}
+        className="col-span-1 text-8xl font-bold tracking-tight text-white pointer-events-none select-none"
+      >
+        {inView && (
+          <div>
+            <Typewriter lines={card.titleLines} speed={35} bold={[card.titleLines[0]]} />
+            <div className="text-4xl font-medium mt-4 mr-20 text-neutral-100">
+              <Typewriter lines={card.descLines} speed={5} bold={card.bold} />
+            </div>
+          </div>
+        )}
+      </motion.div>
+    </section>
+  )
+}
+
+// Page presenting MadCourses with parallax scrolling.
 export default function MadCourses() {
+  const { scrollYProgress } = useScroll()
+  const madCoursesLines = ["MadCourses"]
+  const scaleX = useSpring(scrollYProgress, {
+    stiffness: 100,
+    damping: 50,
+    restDelta: 0.1,
+  })
+
+  const resumeRef = useRef<HTMLAnchorElement>(null)
   const { setTargets } = useCursorContext()
 
   useEffect(() => {
-    setTargets([])
+    setTargets([resumeRef])
     return () => setTargets([])
   }, [setTargets])
 
   return (
-    <main className="flex flex-col h-full px-6 xl:text-7xl lg:text-6xl md:text-5xl sm:text-4xl text-lg font-light text-white">
-      <span className="md:mt-16 sm:mt-8 mt-6 md:ml-8">
-        <Typewriter lines={["MadCourses"]} speed={35} bold={["MadCourses"]}/>
-      </span>
-    </main>
+    <div className="relative">
+      <header className="absolute top-0 inset-x-0 h-16 flex items-center justify-end px-6 z-10 sm:text-lg text-sm font-medium text-white">
+        <p>
+          <a
+            ref={resumeRef}
+            href="/resume.pdf"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Resume
+          </a>
+        </p>
+      </header>
+
+      <main className="flex flex-col h-full px-6 xl:text-7xl lg:text-6xl md:text-5xl sm:text-4xl text-lg text-white">
+        <span className="md:mt-16 sm:mt-8 mt-6 md:ml-8">
+          <Typewriter lines={madCoursesLines} speed={35} bold={["MadCourses"]} />
+        </span>
+
+        <div className="snap-y snap-mandatory">
+          {CARDS.map((card, idx) => (
+            <InfoCard key={idx} card={card} />
+          ))}
+          <motion.div className="fixed bottom-12 left-0 right-0 h-1 bg-white origin-left" style={{ scaleX }} />
+        </div>
+      </main>
+    </div>
   )
 }


### PR DESCRIPTION
## Summary
- create MadCourses cards data
- implement MadCourses page with parallax sections

## Testing
- `npm run build` *(fails: Failed to fetch Merriweather font)*

------
https://chatgpt.com/codex/tasks/task_e_685f68ba43b48331aaa36ccf5430a447