### PR TITLE
Update BreakIt layout

### DIFF
--- a/src/pages/breakit.tsx
+++ b/src/pages/breakit.tsx
@@ -71,7 +71,7 @@ function ImageCard({
   }, [])
 
   return (
-    <section className="relative h-screen snap-start grid grid-cols-2 items-center">
+    <section className="relative h-screen snap-start grid grid-cols-1 lg:grid-cols-2 items-center gap-y-8">
       <Image
         src={`/icons/${card.icon}`}
         alt=""
@@ -80,7 +80,10 @@ function ImageCard({
         aria-hidden
         className="pointer-events-none absolute left-1/11 -translate-x-1/2 -translate-y-1/3 w-[30vw] h-[30vw] -z-10 opacity-75 invert"
       />
-      <div ref={ref} className="relative w-5/12 h-10/12 justify-self-center">
+      <div
+        ref={ref}
+        className="relative w-[320px] h-[692px] justify-self-center"
+      >
         {isHoverCard ? (
           <motion.div
             className="relative w-full h-full rounded-[4rem] bg-black shadow-2xl"
@@ -111,7 +114,7 @@ function ImageCard({
 
       <motion.div
         style={{ y }}
-        className="col-span-1 text-8xl font-bold tracking-tight text-white pointer-events-none select-none"
+        className="col-span-1 text-8xl font-bold tracking-tight text-white pointer-events-none select-none mt-8 lg:mt-0 text-center lg:text-left"
       >
         {inView && (
           <div>


### PR DESCRIPTION
## Summary
- keep BreakIt phone container a fixed size
- stack phone and description vertically on small screens

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6861942eab808331b9a2abc54078ef8d