### PR TITLE
Rename intro to home and add posthome logic

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,15 +2,16 @@
 
 import ColorBackground from "@/components/ColorBackground"
 import Cursor from "@/components/Cursor"
-import Intro from "@/pages/intro"
+import HomePage from "@/pages/home"
+import PostHome from "@/pages/posthome"
 import BreakIt from "@/pages/breakit"
 import MadCourses from "@/pages/madcourses"
 import { CursorProvider } from "@/contexts/CursorContext"
 import { ColorCycleProvider, useColorCycle } from "@/contexts/ColorCycleContext"
-import { useEffect } from "react"
+import { useEffect, useState } from "react"
 
 // Top-level page with global providers.
-export default function Home() {
+export default function Root() {
   return (
     <ColorCycleProvider>
       <CursorProvider>
@@ -27,12 +28,14 @@ export default function Home() {
 // Choose which page to show based on the color index.
 function PageSelector() {
   const { colorIndex } = useColorCycle()
+  const [showHome, setShowHome] = useState(true)
 
   useEffect(() => {
     window.scrollTo({ top: 0 })
+    if (colorIndex !== 0) setShowHome(false)
   }, [colorIndex])
-  
+
   if (colorIndex === 1) return <BreakIt />
   if (colorIndex === 2) return <MadCourses />
-  return <Intro />
+  return showHome ? <HomePage /> : <PostHome />
 }

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -21,7 +21,7 @@ import {
   graduateZ,
 } from "@/styles/classes"
 
-export default function Intro() {
+export default function Home() {
   const resumeRef = useRef<HTMLAnchorElement>(null)
   const githubRef = useRef<HTMLAnchorElement>(null)
   const linkedinRef = useRef<HTMLAnchorElement>(null)

--- a/src/pages/posthome.tsx
+++ b/src/pages/posthome.tsx
@@ -9,9 +9,9 @@ export default function PostHome() {
       className={`${mainLayout} ${mainSpacing} ${mainTextBlack} h-screen flex items-center justify-center`}
     >
       <Typewriter
-        lines={["Thanks for visiting!", "Feel free to explore more soon."]}
+        lines={["Learn more about me!"]}
         speed={35}
-        bold={["Thanks", "explore"]}
+        bold={["me"]}
       />
     </main>
   )

--- a/src/pages/posthome.tsx
+++ b/src/pages/posthome.tsx
@@ -1,0 +1,18 @@
+"use client"
+
+import Typewriter from "@/components/Typewriter"
+import { mainLayout, mainSpacing, mainTextBlack } from "@/styles/classes"
+
+export default function PostHome() {
+  return (
+    <main
+      className={`${mainLayout} ${mainSpacing} ${mainTextBlack} h-screen flex items-center justify-center`}
+    >
+      <Typewriter
+        lines={["Thanks for visiting!", "Feel free to explore more soon."]}
+        speed={35}
+        bold={["Thanks", "explore"]}
+      />
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary
- rename `intro` page to `home`
- add `posthome` page shown after cycling through projects
- update root page logic to swap `home` with `posthome` after the first cycle

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68699058fc2883319f4dea5bea0daa2d